### PR TITLE
Add linting to CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,3 +26,8 @@ jobs:
         npm test
       env:
         CI: true
+    - name: npm lint
+      run: |
+        npm run lint
+      env:
+        CI: true


### PR DESCRIPTION
This adds linting to our CI process. I've broken it out into a seperate step so it's a bit easier to decipher whether there's an issue with the build process versus formatting. You can see this in action here: https://github.com/tylerauerbeck/omp-fe/commit/ff068a4aba5fc731dda16a3646d2abb8d77208e1/checks

That being said -- looks like there will need to be some cleanup done in linting, but the CI change itself looks to be working as expected.