### PR TITLE
Update linting and add dead-link linter

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,21 @@ on:
 - pull_request
     
 jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@0.4.0
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: run-linter
+      run: |
+        yarn install
+        yarn lint
+      env:
+        CI: true
   build:
 
     runs-on: ubuntu-latest
@@ -24,10 +39,5 @@ jobs:
         npm install
         npm run build
         npm test
-      env:
-        CI: true
-    - name: npm lint
-      run: |
-        npm run lint
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,8 +36,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
-        npm install
-        npm run build
-        npm test
+        yarn install
+        yarn build
+        yarn test
       env:
         CI: true


### PR DESCRIPTION
This PR adds:
- Linting of markdown for dead-links
- Breaks code linting out into a seperate task for easier detection of failed steps in CI
- Changes `npm` -> `yarn` as described in the README

Follow-up PR will be submitted to improve performance and avoid running `yarn install` and `yarn build` multiple times.

cc/ @jacobsee @mcanoy 

Passing CI example can be seen here: https://github.com/tylerauerbeck/omp-fe/commit/d5616474e818907ecefbb2b9d031192d8fd74345/checks?check_suite_id=305815698